### PR TITLE
:sparkles: feat/jh-main-level 3-10: Search with queryDSL (comment cou…

### DIFF
--- a/src/main/java/org/example/expert/common/entity/Todo.java
+++ b/src/main/java/org/example/expert/common/entity/Todo.java
@@ -28,7 +28,7 @@ public class Todo extends Timestamped {
     private String contents;
     private String weather;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(
         name = "user_id",
         nullable = false
@@ -59,5 +59,10 @@ public class Todo extends Timestamped {
         this.weather = weather;
         this.user = user;
         this.managers.add(new Manager(user, this));
+    }
+
+    public Todo(
+        String title) {
+        this.title = title;
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponseDto.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponseDto.java
@@ -1,20 +1,21 @@
 package org.example.expert.domain.todo.dto.response;
 
 import lombok.Getter;
-import org.example.expert.common.entity.Todo;
-import org.example.expert.domain.user.dto.response.UserResponseDto;
 
 @Getter
 public class TodoSearchResponseDto {
 
     private final String title;
-    private final UserResponseDto user;
+    private final long managerCount;
+    private final long commentCount;
 
     public TodoSearchResponseDto(
-        Todo todo,
-        UserResponseDto user
+        String title,
+        long managerCount,
+        long commentCount
     ) {
-        this.title = todo.getTitle();
-        this.user = user;
+        this.title = title;
+        this.managerCount = managerCount;
+        this.commentCount = commentCount;
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoQueryRepository.java
@@ -1,5 +1,8 @@
 package org.example.expert.domain.todo.repository;
 
+import static com.querydsl.jpa.JPAExpressions.select;
+import static org.example.expert.common.entity.QComment.comment;
+import static org.example.expert.common.entity.QManager.manager;
 import static org.example.expert.common.entity.QTodo.todo;
 
 import com.querydsl.core.types.Projections;
@@ -10,13 +13,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.expert.common.entity.Todo;
 import org.example.expert.domain.todo.dto.request.TodoSearchRequestDto;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class TodoQueryRepository {
@@ -24,11 +30,11 @@ public class TodoQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     // 주어진 조건에 맞는 일정 리스트를 페이징 처리하여 반환
-    public Page<Todo> search(
+    public Page<TodoSearchResponseDto> search(
         TodoSearchRequestDto dto,
         Pageable pageable
     ) {
-        List<Todo> todoList = new ArrayList<>();
+        List<TodoSearchResponseDto> todoList = new ArrayList<>();
 
         todoList = findTodoList(dto, pageable);
 
@@ -52,21 +58,25 @@ public class TodoQueryRepository {
     }
 
     // 검색 조건에 맞는 일정 목록을 조회
-    private List<Todo> findTodoList(
+    private List<TodoSearchResponseDto> findTodoList(
         TodoSearchRequestDto dto,
         Pageable pageable
     ) {
-        List<Todo> todoList = new ArrayList<>();
+        List<TodoSearchResponseDto> todoList = new ArrayList<>();
 
         todoList = jpaQueryFactory.select(
-                Projections.fields(
-                    Todo.class,
+                Projections.constructor(
+                    TodoSearchResponseDto.class,
                     todo.title,
-                    todo.user
+                    select(manager.id.count())
+                        .from(manager)
+                        .where(manager.todo.id.eq(todo.id)),
+                    select(comment.count())
+                        .from(comment)
+                        .where(comment.todo.id.eq(todo.id))
                 )
             )
             .from(todo)
-            .leftJoin(todo.user)
             .where(
                 containsTitle(dto.getTitle()),
                 goeStartsAt(dto.getStartsAt()),

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -120,15 +120,9 @@ public class TodoService {
 
         log.info("페이지네이션 종료 및 일정 목록 조회 처리");
 
-        Page<Todo> todoPage = todoQueryRepository.search(
+        return todoQueryRepository.search(
             todoDto,
             pageable
-        );
-
-        return todoPage.map(todo -> new TodoSearchResponseDto(
-                todo,
-                new UserResponseDto(todo.getUser())
-            )
         );
     }
 


### PR DESCRIPTION
…nt & manager count)

- use constructor instead of projections field

- remove unnecessary user lookup, previously using 'todo.user left join'

- return the number of comments for each todo via subquery

- return the number of managers for each todo via subquery